### PR TITLE
Export to csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 export JMX_HOST=172.16.1.42
 export JMX_USERNAME=jmxadmin
 export JMX_PASSWORD=jmxadmin
-export DUMP_FILE=metrics.yml (Default to be metrics.yml)
+export DUMP_FILE=metrics.csv (Default to be metrics.yml)
+export DUMP_FORMAT=csv (Default is yaml)
   ```
   * Run
   ```

--- a/src/main/java/metrics/DumpConfig.java
+++ b/src/main/java/metrics/DumpConfig.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "dump")
 public class DumpConfig {
     String file;
+    String format;
 
     public String getFile() {
         return file;
@@ -15,4 +16,12 @@ public class DumpConfig {
     public void setFile(String file) {
         this.file = file;
     }
+
+	public String getFormat() {
+		return format;
+	}
+
+	public void setFormat(String format) {
+		this.format = format;
+	}
 }

--- a/src/main/java/metrics/MetricsApplication.java
+++ b/src/main/java/metrics/MetricsApplication.java
@@ -44,8 +44,11 @@ public class MetricsApplication implements CommandLineRunner{
         if(!file.exists()){
             file.createNewFile();
         }
-//        metric.toYaml(file);
-        metric.toCsv(file);
+        if ("csv".equalsIgnoreCase(dumpConfig.getFormat())) {
+            metric.toCsv(file);
+        } else {
+          metric.toYaml(file);
+        }
     }
     
 }

--- a/src/main/java/metrics/MetricsApplication.java
+++ b/src/main/java/metrics/MetricsApplication.java
@@ -44,7 +44,8 @@ public class MetricsApplication implements CommandLineRunner{
         if(!file.exists()){
             file.createNewFile();
         }
-        metric.toYaml(file);
+//        metric.toYaml(file);
+        metric.toCsv(file);
     }
     
 }

--- a/src/main/java/metrics/objects/Metric.java
+++ b/src/main/java/metrics/objects/Metric.java
@@ -82,9 +82,9 @@ public class Metric {
 		writer.append(',');
 		writer.append("ip");
 		writer.append(',');
-		writer.append("Metricname");
+		writer.append("Metric Name");
 		writer.append(',');
-		writer.append("Metricvalue");
+		writer.append("Metric Value");
 		writer.append('\n');
 		for (String component : jobs.keySet()) {
 			Map<String, Job> jobMap = jobs.get(component);
@@ -94,13 +94,13 @@ public class Metric {
 				for (Integer instanceName : instanceMap.keySet()) {
 					Instance instance = instanceMap.get(instanceName);
 					for (Attribute attribute : instance.getAttributes()) {
-						writer.append(component).append(',');
-						writer.append(objectName).append(',');
+						writer.append(component.replace(',', ':')).append(',');
+						writer.append(objectName.replace(',', ':')).append(',');
 						writer.append(instanceName + "").append(',');
 						writer.append(instance.getIp()).append(',');
-						writer.append(attribute.getName());
+						writer.append(attribute.getName().replace(',', ':'));
 						writer.append(',');
-						writer.append(attribute.getValue());
+						writer.append(attribute.getValue().replace(',', ':'));
 						writer.append('\n');
 					}
 				}

--- a/src/main/java/metrics/objects/Metric.java
+++ b/src/main/java/metrics/objects/Metric.java
@@ -1,6 +1,5 @@
 package metrics.objects;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
@@ -14,63 +13,100 @@ import java.io.IOException;
 import java.util.*;
 
 public class Metric {
-    
-    public Map<String, Map<String, Job>> jobs;
 
-    public Map<String, Map<String, Job>> getJobs() {
-        return jobs;
-    }
+	public Map<String, Map<String, Job>> jobs;
 
-    public void setJobs(Map<String, Map<String, Job>> jobs) {
-        this.jobs = jobs;
-    }
+	public Map<String, Map<String, Job>> getJobs() {
+		return jobs;
+	}
 
-    public Metric(){
-        jobs = new HashMap<String, Map<String, Job>>();
-        jobs.put("VMSysMetrics", new HashMap<String, Job>());
-        jobs.put("UntitledDevMetrics", new HashMap<String, Job>());
-        
-    }
+	public void setJobs(Map<String, Map<String, Job>> jobs) {
+		this.jobs = jobs;
+	}
 
-    private static Logger logger = LoggerFactory.getLogger(Metric.class);
-    
-    public void addJob(MBeanObject mBean, MBeanServerConnection connector) throws Exception{
-        Hashtable<String, String> table = mBean.objectName.getKeyPropertyList();
-        if("untitled_dev".equals(table.get("deployment"))){
-            addJob(jobs.get("UntitledDevMetrics"), table, mBean, connector);
-        }
-        else{
-            addJob(jobs.get("VMSysMetrics"), table, mBean, connector);
-        }
-    }
-    
-    public void toYaml(File file) throws IOException {
-        DumperOptions options = new DumperOptions();
-        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-        Yaml yaml = new Yaml(options);
-        logger.info("Dump the metrics to " + file.getName());
-        yaml.dump(this, new FileWriter(file));
-    }
+	public Metric() {
+		jobs = new HashMap<String, Map<String, Job>>();
+		jobs.put("VMSysMetrics", new HashMap<String, Job>());
+		jobs.put("UntitledDevMetrics", new HashMap<String, Job>());
 
-    
-    private void addJob(Map<String, Job> jobs, Hashtable<String, String> table, MBeanObject mBean, MBeanServerConnection connector) throws Exception{
-        Job job = jobs.get(table.get("job"));
-        if(job == null){
-            job = new Job();
-            jobs.put(table.get("job"), job);
-        }
-        Instance instance = new Instance();
-        instance.setIp(table.get("ip"));
-        MBeanAttributeInfo[] atrs = mBean.getInfo().getAttributes();
-        List<Attribute> attributes = new ArrayList<Attribute>();
-        for(MBeanAttributeInfo atr: atrs){
-            Attribute attribute = new Attribute();
-            attribute.setName(atr.getName());
-            attribute.setValue(connector.getAttribute(mBean.getObjectName(), atr.getName()).toString());
-            attributes.add(attribute);
-        }
-        instance.setAttributes(attributes);
-        job.getInstances().put(Integer.valueOf(table.get("index")), instance);
-        
-    }
+	}
+
+	private static Logger logger = LoggerFactory.getLogger(Metric.class);
+
+	public void addJob(MBeanObject mBean, MBeanServerConnection connector) throws Exception {
+		Hashtable<String, String> table = mBean.objectName.getKeyPropertyList();
+		if ("untitled_dev".equals(table.get("deployment"))) {
+			addJob(jobs.get("UntitledDevMetrics"), table, mBean, connector);
+		} else {
+			addJob(jobs.get("VMSysMetrics"), table, mBean, connector);
+		}
+	}
+
+	public void toYaml(File file) throws IOException {
+		DumperOptions options = new DumperOptions();
+		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		Yaml yaml = new Yaml(options);
+		logger.info("Dump the metrics to " + file.getName());
+		yaml.dump(this, new FileWriter(file));
+	}
+
+	private void addJob(Map<String, Job> jobs, Hashtable<String, String> table, MBeanObject mBean,
+			MBeanServerConnection connector) throws Exception {
+		Job job = jobs.get(table.get("job"));
+		if (job == null) {
+			job = new Job();
+			jobs.put(table.get("job"), job);
+		}
+		Instance instance = new Instance();
+		instance.setIp(table.get("ip"));
+		MBeanAttributeInfo[] atrs = mBean.getInfo().getAttributes();
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		for (MBeanAttributeInfo atr : atrs) {
+			Attribute attribute = new Attribute();
+			attribute.setName(atr.getName());
+			attribute.setValue(connector.getAttribute(mBean.getObjectName(), atr.getName()).toString());
+			attributes.add(attribute);
+		}
+		instance.setAttributes(attributes);
+		job.getInstances().put(Integer.valueOf(table.get("index")), instance);
+	}
+
+	public void toCsv(File file) throws IOException {
+		FileWriter writer = new FileWriter(file.getName());
+
+		writer.append("Component");
+		writer.append(',');
+		writer.append("Objectname");
+		writer.append(',');
+		writer.append("instance");
+		writer.append(',');
+		writer.append("ip");
+		writer.append(',');
+		writer.append("Metricname");
+		writer.append(',');
+		writer.append("Metricvalue");
+		writer.append('\n');
+		for (String component : jobs.keySet()) {
+			Map<String, Job> jobMap = jobs.get(component);
+			for (String objectName : jobMap.keySet()) {
+				Job job = jobMap.get(objectName);
+				Map<Integer, Instance> instanceMap = job.getInstances();
+				for (Integer instanceName : instanceMap.keySet()) {
+					Instance instance = instanceMap.get(instanceName);
+					for (Attribute attribute : instance.getAttributes()) {
+						writer.append(component).append(',');
+						writer.append(objectName).append(',');
+						writer.append(instanceName + "").append(',');
+						writer.append(instance.getIp()).append(',');
+						writer.append(attribute.getName());
+						writer.append(',');
+						writer.append(attribute.getValue());
+						writer.append('\n');
+					}
+				}
+			}
+		}
+		writer.flush();
+		writer.close();
+	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ jmx.username=jmxadmin
 jmx.password=jmxadmin
 #Override with environment variable DUMP_FILE
 dump.file=metrics.yml
+#format: 'yaml' or 'csv'
+dump.format=yaml


### PR DESCRIPTION
This PR is so you can export the mbean graph out to a CSV file. The default is still yaml, but exporting out to csv allows you to easily import into a spreadsheet. This requirement was submitted by NBCU.